### PR TITLE
workflow: Changes the OS image of building binaries in Workflow to ubuntu-20.04.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
           platforms: linux/amd64,linux/arm64/v8
 
   build-binary:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: startsWith(github.ref, 'refs/tags/')
     env:
       GO111MODULE: on


### PR DESCRIPTION
Binaries compiled on the latest ubuntu doesn't work on lower versions, saying glibc version not found.